### PR TITLE
fix(prometheus - pihole): add tld hostname as local dns

### DIFF
--- a/roles/pihole/templates/etc_pihole_by-pool.local.list.j2
+++ b/roles/pihole/templates/etc_pihole_by-pool.local.list.j2
@@ -1,3 +1,3 @@
 {% for host in groups.all %}
-{{ hostvars[host].primary_ip4 }}    {{ host }}.{{ hostvars[host].custom_fields.pool }}.{{ dns_local_tld }}
+{{ hostvars[host].primary_ip4 }}    {{ host }}.{{ hostvars[host].custom_fields.pool }}.{{ dns_local_tld }}  {{ host }}
 {% endfor %}


### PR DESCRIPTION
this is necessary since the prometheus monitoring is built upon the unique hostnames from netbox