### PR TITLE
fix(nextcloud): make pluginscript write output directly to file

### DIFF
--- a/roles/nextcloud/files/etc_systemd_system_prometheus-node-exporter-nextcloud-plugin.service
+++ b/roles/nextcloud/files/etc_systemd_system_prometheus-node-exporter-nextcloud-plugin.service
@@ -4,7 +4,7 @@ Description=Execute nextcloud update checker script every minute
 [Service]
 Type=oneshot
 ExecStart=/usr/local/bin/prometheus-node-exporter-nextcloud-plugin.sh
-StandardOutput=file:/var/lib/prometheus/node-exporter/nextcloud_pending_upgrades.prom
+# StandardOutput=file:/var/lib/prometheus/node-exporter/nextcloud_pending_upgrades.prom
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/nextcloud/files/usr_local_bin_prometheus-node-exporter-nextcloud-plugin.sh
+++ b/roles/nextcloud/files/usr_local_bin_prometheus-node-exporter-nextcloud-plugin.sh
@@ -4,15 +4,20 @@
 LATEST_NEXTCLOUD_RELEASE=""
 NEXTCLOUD_LOCAL_VERSION=""
 
+TEMPFILE=/tmp/nextcloud_pending_upgrades.prom
+OUTPUT=/var/lib/prometheus/node-exporter/nextcloud_pending_upgrades.prom
+
 function write_to_exporter {
     local value=$1
     local origin=$2
     local local_version=$3
     local latest_version=$4
 
-    echo "# HELP node_exporter_nextcloud_upgrade_pending Shows the need for an upgrade of nextcloud (0 = Everything up to date, 1 = upgrade available)"
-    echo -e "# TYPE node_exporter_nextcloud_upgrade_pending gauge"
-    echo -e "node_exporter_nextcloud_upgrade_pending{origin=\"$origin\",local_version=\"$local_version\",latest_version=\"$latest_version\"} $value\n"
+    echo "# HELP node_exporter_nextcloud_upgrade_pending Shows the need for an upgrade of nextcloud (0 = Everything up to date, 1 = upgrade available)" > $TEMPFILE
+    echo -e "# TYPE node_exporter_nextcloud_upgrade_pending gauge" >> $TEMPFILE
+    echo -e "node_exporter_nextcloud_upgrade_pending{origin=\"$origin\",local_version=\"$local_version\",latest_version=\"$latest_version\"} $value\n" >> $TEMPFILE
+
+    mv $TEMPFILE $OUTPUT
 }
 
 function get_local_nextcloud_version {


### PR DESCRIPTION
This intends to circumvent the weird bug, where the file created seems to feature fragmented parts of its supposed content below:
```
# HELP node_exporter_nextcloud_upgrade_pending Shows the need for an upgrade of nextcloud (0 = Everything up to date, 1 = upgrade available)
# TYPE node_exporter_nextcloud_upgrade_pending gauge
node_exporter_nextcloud_upgrade_pending{origin="Nextcloud is on the current version 29.0.3.4",local_version="29.0.3.4",latest_version="29.0.3"} 0

ion="29.0.3.4",latest_version=""} 0 # <- thus rendering it unreadable for the prometheus exporter
```